### PR TITLE
Install TDX Cli Script get latest TDX Cli version using Makefile instead of github api

### DIFF
--- a/.github/workflows/onpullrequest.yml
+++ b/.github/workflows/onpullrequest.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   version-check:
-    runs-on: [ self-hosted ]
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/release/install-tdx-cli-azure.sh
+++ b/release/install-tdx-cli-azure.sh
@@ -31,7 +31,7 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for Azure"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.*\)/\2/g")
+    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-azure-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-azure.sh
+++ b/release/install-tdx-cli-azure.sh
@@ -31,7 +31,7 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for Azure"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl  --silent  https://api.github.com/repos/${REPO_URL}/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
+    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.*\)/\2/g")
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-azure-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-azure.sh
+++ b/release/install-tdx-cli-azure.sh
@@ -31,13 +31,13 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for Azure"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-	ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
-	if [[ $ret_code != 200  ]] ; then
-	    rm -f /tmp/cli_version
-	    print_error_and_exit 'Not able to get cli version'
-	fi
-	CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+    ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
+    if [[ $ret_code != 200  ]] ; then
 	rm -f /tmp/cli_version
+	print_error_and_exit 'Not able to get cli version'
+    fi
+    CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+    rm -f /tmp/cli_version
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-azure-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-azure.sh
+++ b/release/install-tdx-cli-azure.sh
@@ -31,7 +31,13 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for Azure"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+	ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
+	if [[ $ret_code != 200  ]] ; then
+	    rm -f /tmp/cli_version
+	    print_error_and_exit 'Not able to get cli version'
+	fi
+	CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+	rm -f /tmp/cli_version
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-azure-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-dcap.sh
+++ b/release/install-tdx-cli-dcap.sh
@@ -29,7 +29,13 @@ readonly OS=$(uname)
 readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+	ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
+	if [[ $ret_code != 200  ]] ; then
+	    rm -f /tmp/cli_version
+	    print_error_and_exit 'Not able to get cli version'
+	fi
+	CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+	rm -f /tmp/cli_version
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly OS_DISTRO=$(cat /etc/os-release  | grep "^ID=" | sed -e "s/^ID=\(\s\+\)\?\(.*\)\(\s\+\)\?$/\2/g" -e "s/\"//g")

--- a/release/install-tdx-cli-dcap.sh
+++ b/release/install-tdx-cli-dcap.sh
@@ -29,13 +29,13 @@ readonly OS=$(uname)
 readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-	ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
-	if [[ $ret_code != 200  ]] ; then
-	    rm -f /tmp/cli_version
-	    print_error_and_exit 'Not able to get cli version'
-	fi
-	CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+    ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
+    if [[ $ret_code != 200  ]] ; then
 	rm -f /tmp/cli_version
+	print_error_and_exit 'Not able to get cli version'
+    fi
+    CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+    rm -f /tmp/cli_version
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly OS_DISTRO=$(cat /etc/os-release  | grep "^ID=" | sed -e "s/^ID=\(\s\+\)\?\(.*\)\(\s\+\)\?$/\2/g" -e "s/\"//g")

--- a/release/install-tdx-cli-dcap.sh
+++ b/release/install-tdx-cli-dcap.sh
@@ -29,7 +29,7 @@ readonly OS=$(uname)
 readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.*\)/\2/g")
+    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly OS_DISTRO=$(cat /etc/os-release  | grep "^ID=" | sed -e "s/^ID=\(\s\+\)\?\(.*\)\(\s\+\)\?$/\2/g" -e "s/\"//g")

--- a/release/install-tdx-cli-dcap.sh
+++ b/release/install-tdx-cli-dcap.sh
@@ -29,7 +29,7 @@ readonly OS=$(uname)
 readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl  --silent  https://api.github.com/repos/${REPO_URL}/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
+    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.*\)/\2/g")
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly OS_DISTRO=$(cat /etc/os-release  | grep "^ID=" | sed -e "s/^ID=\(\s\+\)\?\(.*\)\(\s\+\)\?$/\2/g" -e "s/\"//g")

--- a/release/install-tdx-cli-gcp.sh
+++ b/release/install-tdx-cli-gcp.sh
@@ -30,7 +30,13 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for GCP"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+	ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
+	if [[ $ret_code != 200  ]] ; then
+	    rm -f /tmp/cli_version
+	    print_error_and_exit 'Not able to get cli version'
+	fi
+	CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+	rm -f /tmp/cli_version
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-gcp-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-gcp.sh
+++ b/release/install-tdx-cli-gcp.sh
@@ -30,7 +30,7 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for GCP"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl  --silent  https://api.github.com/repos/${REPO_URL}/releases/latest | grep -Po '"tag_name": "\K.*?(?=")')
+    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.*\)/\2/g")
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-gcp-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-gcp.sh
+++ b/release/install-tdx-cli-gcp.sh
@@ -30,7 +30,7 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for GCP"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.*\)/\2/g")
+    CLI_VERSION=$(curl -s  ${RAW_MAKEFILE} | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-gcp-${CLI_VERSION}.tar.gz"

--- a/release/install-tdx-cli-gcp.sh
+++ b/release/install-tdx-cli-gcp.sh
@@ -30,13 +30,13 @@ readonly REPO_URL="intel/trustauthority-client-for-go"
 readonly CLI_NAME="Intel Trust Authority Client for GCP"
 readonly RAW_MAKEFILE="https://raw.githubusercontent.com/${REPO_URL}/main/tdx-cli/Makefile"
 if [ -z "${CLI_VERSION}" ]; then
-	ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
-	if [[ $ret_code != 200  ]] ; then
-	    rm -f /tmp/cli_version
-	    print_error_and_exit 'Not able to get cli version'
-	fi
-	CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+    ret_code=$(curl -s  ${RAW_MAKEFILE} -w '%{http_code}' -o /tmp/cli_version)
+    if [[ $ret_code != 200  ]] ; then
 	rm -f /tmp/cli_version
+	print_error_and_exit 'Not able to get cli version'
+    fi
+    CLI_VERSION=$(cat /tmp/cli_version | grep '^VERSION :=' | sed -e "s/\(^VERSION.*\)\(v[0-9]\+.[0-9]\+.[0-9]\+\)/\2/g")
+    rm -f /tmp/cli_version
 fi
 readonly INSTALL_DIRECTORY=/usr/bin
 readonly TAR_NAME="trustauthority-cli-gcp-${CLI_VERSION}.tar.gz"

--- a/tdx-cli/Makefile
+++ b/tdx-cli/Makefile
@@ -4,7 +4,7 @@
 APPNAME := trustauthority-cli
 GITCOMMIT := $(shell git describe --always)
 GITCOMMITDATE := $(shell git log -1 --date=short --pretty=format:%cd)
-VERSION := v1.2.0
+VERSION := v1.2.1
 
 cli:
 	CGO_CFLAGS="-O2 -D_FORTIFY_SOURCE=2" go build -buildmode=pie -trimpath -ldflags "-s -linkmode=external -extldflags -Wl,-O1,-z,relro,-z,now \


### PR DESCRIPTION
These changes introduced because of github api rate limit issue.