### PR TITLE
Add nvtrust support

### DIFF
--- a/.github/workflows/onpullrequest.yml
+++ b/.github/workflows/onpullrequest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.23"
+          go-version: "1.22.3"
 
       - name: Style Checker
         run: |

--- a/.github/workflows/onpullrequest.yml
+++ b/.github/workflows/onpullrequest.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.22.3'
+          go-version: "1.23"
 
       - name: Style Checker
         run: |

--- a/.github/workflows/onpullrequest.yml
+++ b/.github/workflows/onpullrequest.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   security-file-check:
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -21,7 +21,7 @@ jobs:
           fi
 
   version-check:
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -36,7 +36,7 @@ jobs:
           fi
 
   build-test-scan:
-    runs-on: [ ubuntu-20.04 ]
+    runs-on: [ubuntu-20.04]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:

--- a/.github/workflows/onpullrequest.yml
+++ b/.github/workflows/onpullrequest.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   security-file-check:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -21,7 +21,7 @@ jobs:
           fi
 
   version-check:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -36,7 +36,7 @@ jobs:
           fi
 
   build-test-scan:
-    runs-on: [ubuntu-20.04]
+    runs-on: [ ubuntu-20.04 ]
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:

--- a/go-nvgpu/gpu_adapter.go
+++ b/go-nvgpu/gpu_adapter.go
@@ -39,7 +39,7 @@ func WithGpuAttester(gpuAttester GPUAttester) Option {
 
 func NewCompositeEvidenceAdapter(opts ...Option) connector.CompositeEvidenceAdapter {
 	options := &GPUAdapterOptions{
-		GpuAttester: gonvtrust.NewGpuAttester(false),
+		GpuAttester: gonvtrust.NewGpuAttester(nil),
 	}
 	for _, opt := range opts {
 		opt(options)

--- a/go-nvgpu/gpu_adapter.go
+++ b/go-nvgpu/gpu_adapter.go
@@ -1,0 +1,99 @@
+package nvgpu
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/confidentsecurity/go-nvtrust/pkg/gonvtrust"
+	"github.com/intel/trustauthority-client/go-connector"
+)
+
+type GPUEvidence struct {
+	Evidence      string                  `json:"evidence"`
+	Certificate   string                  `json:"certificate"`
+	Nonce         string                  `json:"gpu_nonce"`
+	VerifierNonce connector.VerifierNonce `json:"verifier_nonce"`
+}
+
+type GPUAdapter struct {
+	gpuAttester GPUAttester
+}
+
+type GPUAttester interface {
+	GetRemoteEvidence([]byte) ([]gonvtrust.RemoteEvidence, error)
+}
+
+type GPUAdapterOptions struct {
+	GpuAttester GPUAttester
+}
+
+type Option func(*GPUAdapterOptions)
+
+func WithGpuAttester(gpuAttester GPUAttester) Option {
+	return func(options *GPUAdapterOptions) {
+		options.GpuAttester = gpuAttester
+	}
+}
+
+func NewCompositeEvidenceAdapter(opts ...Option) connector.CompositeEvidenceAdapter {
+	options := &GPUAdapterOptions{
+		GpuAttester: gonvtrust.NewGpuAttester(false),
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+	return &GPUAdapter{
+		gpuAttester: options.GpuAttester,
+	}
+}
+
+func (*GPUAdapter) GetEvidenceIdentifier() string {
+	return "nvgpu"
+}
+
+func (g *GPUAdapter) collectEvidence(nonce []byte) (GPUEvidence, error) {
+	hash := sha256.Sum256(nonce)
+	// pass in false to signify we are not in test mode
+	evidenceList, err := g.gpuAttester.GetRemoteEvidence(hash[:])
+	if err != nil {
+		return GPUEvidence{}, fmt.Errorf("failed to get remote evidence: %v", err)
+	}
+
+	if len(evidenceList) == 0 {
+		return GPUEvidence{}, fmt.Errorf("no evidence returned")
+	}
+	// only single gpu attestation is supported for now
+	rawEvidence := evidenceList[0]
+
+	evidenceBytes, err := base64.StdEncoding.DecodeString(rawEvidence.Evidence)
+	if err != nil {
+		return GPUEvidence{}, fmt.Errorf("failed to decode evidence: %v", err)
+	}
+	hexEvidence := hex.EncodeToString(evidenceBytes)
+	rawEvidence.Evidence = base64.StdEncoding.EncodeToString([]byte(hexEvidence))
+
+	hexNonce := fmt.Sprintf("%x", hash)
+	return GPUEvidence{
+		Nonce:       hexNonce,
+		Evidence:    rawEvidence.Evidence,
+		Certificate: rawEvidence.Certificate,
+	}, nil
+}
+
+func (adapter *GPUAdapter) GetEvidence(verifierNonce *connector.VerifierNonce, userData []byte) (any, error) {
+	var nonce []byte
+	if verifierNonce != nil {
+		nonce = append(verifierNonce.Val, verifierNonce.Iat[:]...)
+	}
+
+	evidence, err := adapter.collectEvidence(nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	evidence.VerifierNonce = *verifierNonce
+
+	return &evidence, nil
+}

--- a/go-nvgpu/gpu_adapter.go
+++ b/go-nvgpu/gpu_adapter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/confidentsecurity/go-nvtrust/pkg/gonvtrust"
 	"github.com/intel/trustauthority-client/go-connector"
+	"github.com/sirupsen/logrus"
 )
 
 const HopperArch = "hopper"
@@ -68,6 +69,11 @@ func (g *GPUAdapter) collectEvidence(nonce []byte) (GPUEvidence, error) {
 	if len(evidenceList) == 0 {
 		return GPUEvidence{}, fmt.Errorf("no evidence returned")
 	}
+
+	if len(evidenceList) > 1 {
+		logrus.Warn("more than one evidence returned, only using the first one")
+	}
+
 	// only single gpu attestation is supported for now
 	rawEvidence := evidenceList[0]
 
@@ -89,7 +95,7 @@ func (g *GPUAdapter) collectEvidence(nonce []byte) (GPUEvidence, error) {
 
 func (adapter *GPUAdapter) GetEvidence(verifierNonce *connector.VerifierNonce, userData []byte) (any, error) {
 	var nonce []byte
-	if verifierNonce != nil {
+	if verifierNonce != nil && len(verifierNonce.Val) > 0 && len(verifierNonce.Iat) > 0 {
 		nonce = append(verifierNonce.Val, verifierNonce.Iat[:]...)
 	} else {
 		nonce = make([]byte, 32)

--- a/go-nvgpu/gpu_adapter_test.go
+++ b/go-nvgpu/gpu_adapter_test.go
@@ -1,0 +1,122 @@
+package nvgpu
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/confidentsecurity/go-nvtrust/pkg/gonvtrust"
+	"github.com/intel/trustauthority-client/go-connector"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockGPUAttester is a mock implementation of the GPUAttester interface
+type MockGPUAttester struct {
+	mock.Mock
+}
+
+func (m *MockGPUAttester) GetRemoteEvidence(nonce []byte) ([]gonvtrust.RemoteEvidence, error) {
+	args := m.Called(nonce)
+	return args.Get(0).([]gonvtrust.RemoteEvidence), args.Error(1)
+}
+
+func TestNewCompositeEvidenceAdapter(t *testing.T) {
+	mockAttester := new(MockGPUAttester)
+	adapter := NewCompositeEvidenceAdapter(WithGpuAttester(mockAttester))
+
+	assert.NotNil(t, adapter)
+	assert.IsType(t, &GPUAdapter{}, adapter)
+}
+
+func TestGetEvidenceIdentifier(t *testing.T) {
+	mockAttester := new(MockGPUAttester)
+	adapter := NewCompositeEvidenceAdapter(WithGpuAttester(mockAttester))
+
+	assert.Equal(t, "nvgpu", adapter.GetEvidenceIdentifier())
+}
+
+func TestGetEvidence(t *testing.T) {
+	mockAttester := new(MockGPUAttester)
+	adapter := NewCompositeEvidenceAdapter(WithGpuAttester(mockAttester))
+
+	verifierNonce := &connector.VerifierNonce{
+		Val: []byte("verifier_nonce"),
+		Iat: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	nonce := append(verifierNonce.Val, verifierNonce.Iat[:]...)
+	hash := sha256.Sum256(nonce)
+	expectedEvidence := gonvtrust.RemoteEvidence{
+		Evidence:    base64.StdEncoding.EncodeToString([]byte("test_evidence")),
+		Certificate: "test_certificate",
+	}
+	mockAttester.On("GetRemoteEvidence", hash[:]).Return([]gonvtrust.RemoteEvidence{expectedEvidence}, nil)
+
+	evidence, err := adapter.GetEvidence(verifierNonce, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, evidence)
+
+	gpuEvidence, ok := evidence.(*GPUEvidence)
+	assert.True(t, ok)
+	assert.Equal(t, expectedEvidence.Certificate, gpuEvidence.Certificate)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte(hex.EncodeToString([]byte("test_evidence")))), gpuEvidence.Evidence)
+	assert.Equal(t, fmt.Sprintf("%x", hash), gpuEvidence.Nonce)
+	assert.Equal(t, *verifierNonce, gpuEvidence.VerifierNonce)
+}
+
+func TestGetEvidence_AttesterReturnsError(t *testing.T) {
+	mockAttester := new(MockGPUAttester)
+	adapter := NewCompositeEvidenceAdapter(WithGpuAttester(mockAttester))
+
+	verifierNonce := &connector.VerifierNonce{
+		Val: []byte("verifier_nonce"),
+		Iat: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	nonce := append(verifierNonce.Val, verifierNonce.Iat[:]...)
+	hash := sha256.Sum256(nonce)
+	mockAttester.On("GetRemoteEvidence", hash[:]).Return([]gonvtrust.RemoteEvidence{}, fmt.Errorf("test_error"))
+
+	evidence, err := adapter.GetEvidence(verifierNonce, nil)
+	assert.Error(t, err)
+	assert.Empty(t, evidence)
+}
+
+func TestGetEvidence_AttesterReturnsNoEvidence(t *testing.T) {
+	mockAttester := new(MockGPUAttester)
+	adapter := NewCompositeEvidenceAdapter(WithGpuAttester(mockAttester))
+
+	verifierNonce := &connector.VerifierNonce{
+		Val: []byte("verifier_nonce"),
+		Iat: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	nonce := append(verifierNonce.Val, verifierNonce.Iat[:]...)
+	hash := sha256.Sum256(nonce)
+	mockAttester.On("GetRemoteEvidence", hash[:]).Return([]gonvtrust.RemoteEvidence{}, nil)
+
+	evidence, err := adapter.GetEvidence(verifierNonce, nil)
+	assert.Error(t, err)
+	assert.Empty(t, evidence)
+}
+
+func TestGetEvidence_AttesterReturnsInvalidBase64(t *testing.T) {
+	mockAttester := new(MockGPUAttester)
+	adapter := NewCompositeEvidenceAdapter(WithGpuAttester(mockAttester))
+
+	verifierNonce := &connector.VerifierNonce{
+		Val: []byte("verifier_nonce"),
+		Iat: []byte{1, 2, 3, 4, 5, 6, 7, 8},
+	}
+	nonce := append(verifierNonce.Val, verifierNonce.Iat[:]...)
+	hash := sha256.Sum256(nonce)
+	expectedEvidence := gonvtrust.RemoteEvidence{
+		Evidence:    "invalid_base64",
+		Certificate: "test_certificate",
+	}
+	mockAttester.On("GetRemoteEvidence", hash[:]).Return([]gonvtrust.RemoteEvidence{expectedEvidence}, nil)
+
+	evidence, err := adapter.GetEvidence(verifierNonce, nil)
+	assert.Error(t, err)
+	assert.Empty(t, evidence)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@
 
 module github.com/intel/trustauthority-client
 
-go 1.22
+go 1.23
 
 require (
 	github.com/canonical/go-tpm2 v1.7.6
+	github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526
 	github.com/goccy/go-json v0.10.2
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/go-configfs-tsm v0.2.2
@@ -16,10 +17,11 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
+	github.com/NVIDIA/go-nvml v0.12.4-0 // indirect
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
@@ -39,3 +41,5 @@ require (
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/NVIDIA/go-nvml => github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@
 
 module github.com/intel/trustauthority-client
 
-go 1.23
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/canonical/go-tpm2 v1.7.6
-	github.com/confidentsecurity/go-nvtrust v0.1.1
+	github.com/confidentsecurity/go-nvtrust v0.1.2
 	github.com/goccy/go-json v0.10.2
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/go-configfs-tsm v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.23
 
 require (
 	github.com/canonical/go-tpm2 v1.7.6
-	github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526
+	github.com/confidentsecurity/go-nvtrust v0.1.1
 	github.com/goccy/go-json v0.10.2
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/go-configfs-tsm v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkST
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382 h1:RhxhEDOaR076IHRBlcBHCITU9koTkkc0aDkMDoMKN5E=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
-github.com/confidentsecurity/go-nvtrust v0.1.1 h1:+yKGHDJErEf2HqBogVYLPPatZ+9l5EkiKzvypiZS+gU=
-github.com/confidentsecurity/go-nvtrust v0.1.1/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
+github.com/confidentsecurity/go-nvtrust v0.1.2 h1:emmbikw2wK7roMRF50WhHGa86XP0A9EpkXKbJXp2VHY=
+github.com/confidentsecurity/go-nvtrust v0.1.2/go.mod h1:f3XrJL9Bfo06tDxM415iKsj1l5cHAH4N4qEdKambhNo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkST
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382 h1:RhxhEDOaR076IHRBlcBHCITU9koTkkc0aDkMDoMKN5E=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
-github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526 h1:GqjIb5YUV3FNaDIpfd1+QHTPEJ8/U2G4uhP4P0fD83g=
-github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
+github.com/confidentsecurity/go-nvtrust v0.1.1 h1:+yKGHDJErEf2HqBogVYLPPatZ+9l5EkiKzvypiZS+gU=
+github.com/confidentsecurity/go-nvtrust v0.1.1/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 h1:USzK
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkSTSQ=
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
+github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382 h1:RhxhEDOaR076IHRBlcBHCITU9koTkkc0aDkMDoMKN5E=
+github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
+github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526 h1:GqjIb5YUV3FNaDIpfd1+QHTPEJ8/U2G4uhP4P0fD83g=
+github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -62,8 +66,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=

--- a/tdx-cli/Makefile
+++ b/tdx-cli/Makefile
@@ -4,7 +4,7 @@
 APPNAME := trustauthority-cli
 GITCOMMIT := $(shell git describe --always)
 GITCOMMITDATE := $(shell git log -1 --date=short --pretty=format:%cd)
-VERSION := v1.9.1
+VERSION := v1.10.0
 
 cli:
 	CGO_ENABLED=1 CGO_CFLAGS="-O2 -D_FORTIFY_SOURCE=2" go build -buildmode=pie -trimpath -ldflags "-s -linkmode=external -extldflags '-Wl,-O1,-z,relro,-z,lazy' \

--- a/tdx-cli/Makefile
+++ b/tdx-cli/Makefile
@@ -4,7 +4,7 @@
 APPNAME := trustauthority-cli
 GITCOMMIT := $(shell git describe --always)
 GITCOMMITDATE := $(shell git log -1 --date=short --pretty=format:%cd)
-VERSION := v1.9.0
+VERSION := v1.9.1
 
 cli:
 	CGO_ENABLED=1 CGO_CFLAGS="-O2 -D_FORTIFY_SOURCE=2" go build -buildmode=pie -trimpath -ldflags "-s -linkmode=external -extldflags '-Wl,-O1,-z,relro,-z,lazy' \

--- a/tdx-cli/Makefile
+++ b/tdx-cli/Makefile
@@ -7,7 +7,7 @@ GITCOMMITDATE := $(shell git log -1 --date=short --pretty=format:%cd)
 VERSION := v1.9.0
 
 cli:
-	CGO_ENABLED=1 CGO_CFLAGS="-O2 -D_FORTIFY_SOURCE=2" go build -buildmode=pie -trimpath -ldflags "-s -linkmode=external -extldflags -Wl,-O1,-z,relro,-z,now \
+	CGO_ENABLED=1 CGO_CFLAGS="-O2 -D_FORTIFY_SOURCE=2" go build -buildmode=pie -trimpath -ldflags "-s -linkmode=external -extldflags '-Wl,-O1,-z,relro,-z,lazy' \
 	    -X github.com/intel/trustauthority-client/tdx-cli/cmd.Version=$(VERSION) -X github.com/intel/trustauthority-client/tdx-cli/cmd.BuildDate=$(GITCOMMITDATE) \
 	    -X github.com/intel/trustauthority-client/tdx-cli/cmd.GitHash=$(GITCOMMIT)" -o ${APPNAME}
 

--- a/tdx-cli/cmd/evidence.go
+++ b/tdx-cli/cmd/evidence.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/intel/trustauthority-client/go-connector"
+	"github.com/intel/trustauthority-client/go-nvgpu"
 	"github.com/intel/trustauthority-client/go-tpm"
 	"github.com/intel/trustauthority-client/tdx-cli/constants"
 
@@ -26,6 +27,7 @@ func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 
 	var withTpm bool
 	var withTdx bool
+	var withNvGpu bool
 	var tokenSigningAlg string
 	var noVerifierNonce bool
 	var configPath string
@@ -105,6 +107,11 @@ func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 				builderOptions = append(builderOptions, connector.WithEvidenceAdapter(tdxAdapter))
 			}
 
+			if withNvGpu {
+				gpuAdapter := nvgpu.NewCompositeEvidenceAdapter()
+				builderOptions = append(builderOptions, connector.WithEvidenceAdapter(gpuAdapter))
+			}
+
 			if !noVerifierNonce {
 				// only create the connector if the user has opted to include a verifier
 				// nonce
@@ -165,6 +172,7 @@ func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 	cmd.Flags().StringVarP(&configPath, constants.ConfigOptions.Name, constants.ConfigOptions.ShortHand, "", constants.ConfigOptions.Description)
 	cmd.Flags().BoolVar(&withTpm, constants.WithTpmOptions.Name, false, constants.WithTpmOptions.Description)
 	cmd.Flags().BoolVar(&withTdx, constants.WithTdxOptions.Name, false, constants.WithTdxOptions.Description)
+	cmd.Flags().BoolVar(&withNvGpu, constants.WithNvGpuOptions.Name, false, constants.WithNvGpuOptions.Description)
 	cmd.Flags().BoolVar(&noVerifierNonce, constants.NoVerifierNonceOptions.Name, false, constants.NoVerifierNonceOptions.Description)
 	cmd.Flags().StringVarP(&userData, constants.UserDataOptions.Name, constants.UserDataOptions.ShortHand, "", constants.UserDataOptions.Description)
 	cmd.Flags().StringVarP(&policyIds, constants.PolicyIdsOptions.Name, constants.PolicyIdsOptions.ShortHand, "", constants.PolicyIdsOptions.Description)

--- a/tdx-cli/cmd/token.go
+++ b/tdx-cli/cmd/token.go
@@ -17,6 +17,7 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/uuid"
 	"github.com/intel/trustauthority-client/go-connector"
+	"github.com/intel/trustauthority-client/go-nvgpu"
 	"github.com/intel/trustauthority-client/go-tpm"
 	"github.com/intel/trustauthority-client/tdx-cli/constants"
 	"github.com/pkg/errors"
@@ -62,6 +63,7 @@ func newTokenCommand(tdxAdapterFactory TdxAdapterFactory,
 	tokenCmd.Flags().Bool(constants.PolicyMustMatchOptions.Name, false, constants.PolicyMustMatchOptions.Description)
 	tokenCmd.Flags().Bool(constants.WithTdxOptions.Name, false, constants.WithTdxOptions.Description)
 	tokenCmd.Flags().Bool(constants.WithTpmOptions.Name, false, constants.WithTpmOptions.Description)
+	tokenCmd.Flags().Bool(constants.WithNvGpuOptions.Name, false, constants.WithNvGpuOptions.Description)
 	tokenCmd.Flags().Bool(constants.NoVerifierNonceOptions.Name, false, constants.NoVerifierNonceOptions.Description)
 	tokenCmd.Flags().Bool(constants.WithImaLogsOptions.Name, false, constants.WithImaLogsOptions.Description)
 	tokenCmd.Flags().Bool(constants.WithEventLogsOptions.Name, false, constants.WithEventLogsOptions.Description)
@@ -172,6 +174,12 @@ func getToken(cmd *cobra.Command,
 		return err
 	}
 
+	withNvGpu, err := cmd.Flags().GetBool(constants.WithNvGpuOptions.Name)
+
+	if err != nil {
+		return err
+	}
+
 	withImaLogs, err := cmd.Flags().GetBool(constants.WithImaLogsOptions.Name)
 	if err != nil {
 		return err
@@ -187,10 +195,15 @@ func getToken(cmd *cobra.Command,
 		return err
 	}
 
-	// backward compatibility cli options: if the user did not specify "--tdx" or "--tpm" options,
+	// backward compatibility cli options: if the user did not specify "--tdx, "--tpm" or "--nvgpu" options,
 	// include TDX evidence by default
-	if !withTdx && !withTpm {
+	if !withTdx && !withTpm && !withNvGpu {
 		withTdx = true
+	}
+
+	eventLogsPath, err := cmd.Flags().GetString(constants.EventLogsPathOptions.Name)
+	if err != nil {
+		return err
 	}
 
 	var userDataBytes []byte
@@ -274,6 +287,11 @@ func getToken(cmd *cobra.Command,
 		}
 
 		builderOptions = append(builderOptions, connector.WithEvidenceAdapter(tpmAdapter))
+	}
+
+	if withNvGpu {
+		gpuAdapter := nvgpu.NewCompositeEvidenceAdapter()
+		builderOptions = append(builderOptions, connector.WithEvidenceAdapter(gpuAdapter))
 	}
 
 	evidenceBuilder, err := connector.NewEvidenceBuilder(builderOptions...)

--- a/tdx-cli/cmd/token.go
+++ b/tdx-cli/cmd/token.go
@@ -201,11 +201,6 @@ func getToken(cmd *cobra.Command,
 		withTdx = true
 	}
 
-	eventLogsPath, err := cmd.Flags().GetString(constants.EventLogsPathOptions.Name)
-	if err != nil {
-		return err
-	}
-
 	var userDataBytes []byte
 	if userData != "" {
 		userDataBytes, err = base64.StdEncoding.DecodeString(userData)

--- a/tdx-cli/cmd/token.go
+++ b/tdx-cli/cmd/token.go
@@ -175,7 +175,6 @@ func getToken(cmd *cobra.Command,
 	}
 
 	withNvGpu, err := cmd.Flags().GetBool(constants.WithNvGpuOptions.Name)
-
 	if err != nil {
 		return err
 	}

--- a/tdx-cli/constants/constants.go
+++ b/tdx-cli/constants/constants.go
@@ -46,6 +46,7 @@ var (
 	ConfigOptions          = CommandOptions{"config", "c", "Trust Authority config in JSON format"}
 	WithTpmOptions         = CommandOptions{"tpm", "", "Include TPM evidence in evidence output"}
 	WithTdxOptions         = CommandOptions{"tdx", "", "Include TDX evidence in evidence output"}
+	WithNvGpuOptions       = CommandOptions{"nvgpu", "", "Include NVGPU evidence in evidence output"}
 	NoVerifierNonceOptions = CommandOptions{"no-verifier-nonce", "", "Do not include an ITA verifier-nonce in evidence"}
 	UserDataOptions        = CommandOptions{"user-data", "u", "User data in hex or base64 encoded format"}
 	PolicyIdsOptions       = CommandOptions{"policy-ids", "p", "Trust Authority Policy Ids, comma separated"}

--- a/tdx-cli/go.mod
+++ b/tdx-cli/go.mod
@@ -4,7 +4,9 @@
 
 module github.com/intel/trustauthority-client/tdx-cli
 
-go 1.23
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
@@ -20,7 +22,7 @@ require (
 	github.com/NVIDIA/go-nvml v0.12.4-0 // indirect
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 // indirect
 	github.com/canonical/go-tpm2 v1.7.6 // indirect
-	github.com/confidentsecurity/go-nvtrust v0.1.1 // indirect
+	github.com/confidentsecurity/go-nvtrust v0.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/tdx-cli/go.mod
+++ b/tdx-cli/go.mod
@@ -4,9 +4,7 @@
 
 module github.com/intel/trustauthority-client/tdx-cli
 
-go 1.22
-
-toolchain go1.22.0
+go 1.23
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.1
@@ -15,12 +13,14 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
+	github.com/NVIDIA/go-nvml v0.12.4-0 // indirect
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 // indirect
 	github.com/canonical/go-tpm2 v1.7.6 // indirect
+	github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
@@ -48,3 +48,5 @@ require (
 )
 
 replace github.com/intel/trustauthority-client => ../
+
+replace github.com/NVIDIA/go-nvml => github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382

--- a/tdx-cli/go.mod
+++ b/tdx-cli/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/NVIDIA/go-nvml v0.12.4-0 // indirect
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 // indirect
 	github.com/canonical/go-tpm2 v1.7.6 // indirect
-	github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526 // indirect
+	github.com/confidentsecurity/go-nvtrust v0.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect

--- a/tdx-cli/go.sum
+++ b/tdx-cli/go.sum
@@ -2,6 +2,10 @@ github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 h1:USzK
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9/go.mod h1:Zrs3YjJr+w51u0R/dyLh/oWt/EcBVdLPCVFYC4daW5s=
 github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkSTSQ=
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
+github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382 h1:RhxhEDOaR076IHRBlcBHCITU9koTkkc0aDkMDoMKN5E=
+github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
+github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526 h1:GqjIb5YUV3FNaDIpfd1+QHTPEJ8/U2G4uhP4P0fD83g=
+github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -76,8 +80,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=

--- a/tdx-cli/go.sum
+++ b/tdx-cli/go.sum
@@ -4,8 +4,8 @@ github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkST
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382 h1:RhxhEDOaR076IHRBlcBHCITU9koTkkc0aDkMDoMKN5E=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
-github.com/confidentsecurity/go-nvtrust v0.1.1 h1:+yKGHDJErEf2HqBogVYLPPatZ+9l5EkiKzvypiZS+gU=
-github.com/confidentsecurity/go-nvtrust v0.1.1/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
+github.com/confidentsecurity/go-nvtrust v0.1.2 h1:emmbikw2wK7roMRF50WhHGa86XP0A9EpkXKbJXp2VHY=
+github.com/confidentsecurity/go-nvtrust v0.1.2/go.mod h1:f3XrJL9Bfo06tDxM415iKsj1l5cHAH4N4qEdKambhNo=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tdx-cli/go.sum
+++ b/tdx-cli/go.sum
@@ -4,8 +4,8 @@ github.com/canonical/go-tpm2 v1.7.6 h1:9k9OAEEp9xKp4h2WJwfTUNivblJi4L5Wjx7Q/LkST
 github.com/canonical/go-tpm2 v1.7.6/go.mod h1:Dz0PQRmoYrmk/4BLILjRA+SFzuqEo1etAvYeAJiMhYU=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382 h1:RhxhEDOaR076IHRBlcBHCITU9koTkkc0aDkMDoMKN5E=
 github.com/confidentsecurity/go-nvml v0.0.0-20250102214226-9a52cebf0382/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
-github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526 h1:GqjIb5YUV3FNaDIpfd1+QHTPEJ8/U2G4uhP4P0fD83g=
-github.com/confidentsecurity/go-nvtrust v0.0.0-20250109124608-b2cfc0e15526/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
+github.com/confidentsecurity/go-nvtrust v0.1.1 h1:+yKGHDJErEf2HqBogVYLPPatZ+9l5EkiKzvypiZS+gU=
+github.com/confidentsecurity/go-nvtrust v0.1.1/go.mod h1:cNYqe6G3G9w/wbQo8++maVfrQEUn3iisbBmYOnD5s7s=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Duplicate of: #39 


This PR contains an attestation adapter for nvidia GPU. It relies on go-nvtrust that we created. go-nvtrust allows to extract raw evidence and certificate chain from GPU.


cc @AI-Memory @arvind5 