### PR TITLE
Fixed key pair generation issue

### DIFF
--- a/go-tdx/crypto.go
+++ b/go-tdx/crypto.go
@@ -48,7 +48,7 @@ func GenerateKeyPair(km *KeyMetadata) ([]byte, []byte, error) {
 	defer ZeroizeRSAPrivateKey(keyPair)
 
 	privateKey := &pem.Block{
-		Type:  "PRIVATE KEY",
+		Type:  "RSA PRIVATE KEY",
 		Bytes: x509.MarshalPKCS1PrivateKey(keyPair),
 	}
 	defer ZeroizeByteArray(privateKey.Bytes)


### PR DESCRIPTION
tdx.GenerateKeyPair hard-codes the PEM block type as "PRIVATE KEY" while serializing the bytes with x509.MarshalPKCS1PrivateKey, the output is indeed PKCS#1 data wrapped in a PKCS#8-style label. This causes the error to load the private key generated by trustauthority-cli. PKCS#1 should use Type: "RSA PRIVATE KEY" wheras PKCS#8 should use Type: "PRIVATE KEY". Align the header with the payload without changing the logic.