### PR TITLE
Enable user provided ITA nonce

### DIFF
--- a/tdx-cli/cmd/evidence.go
+++ b/tdx-cli/cmd/evidence.go
@@ -21,6 +21,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// parseVerifierNonce decodes a JSON-encoded VerifierNonce provided by the user.
+func parseVerifierNonce(raw string) (*connector.VerifierNonce, error) {
+	var nonce connector.VerifierNonce
+	if err := json.Unmarshal([]byte(raw), &nonce); err != nil {
+		return nil, errors.Wrap(err, "Failed to parse verifier-nonce JSON")
+	}
+	return &nonce, nil
+}
+
 func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 	tpmAdapterFactory tpm.TpmAdapterFactory,
 	cfgFactory ConfigFactory,
@@ -31,6 +40,7 @@ func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 	var withNvGpu bool
 	var tokenSigningAlg string
 	var noVerifierNonce bool
+	var verifierNonceJSON string
 	var configPath string
 	var policiesMustMatch bool
 	var userData string
@@ -128,9 +138,18 @@ func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 				builderOptions = append(builderOptions, connector.WithEvidenceAdapter(gpuAdapter))
 			}
 
-			if !noVerifierNonce {
-				// only create the connector if the user has opted to include a verifier
-				// nonce
+			if noVerifierNonce && verifierNonceJSON != "" {
+				return errors.New("--no-verifier-nonce and --verifier-nonce are mutually exclusive")
+			}
+
+			if verifierNonceJSON != "" {
+				parsedNonce, err := parseVerifierNonce(verifierNonceJSON)
+				if err != nil {
+					return err
+				}
+				builderOptions = append(builderOptions, connector.WithVerifierNonce(&staticNonceConnector{nonce: parsedNonce}))
+			} else if !noVerifierNonce {
+				// default: fetch a fresh verifier nonce from ITA
 				if cfg.TrustAuthorityApiUrl == "" {
 					return errors.New("The Trust Authority API URL must be present in config")
 				}
@@ -187,6 +206,7 @@ func newEvidenceCommand(tdxAdapterFactory TdxAdapterFactory,
 	cmd.Flags().BoolVar(&withTdx, constants.WithTdxOptions.Name, false, constants.WithTdxOptions.Description)
 	cmd.Flags().BoolVar(&withNvGpu, constants.WithNvGpuOptions.Name, false, constants.WithNvGpuOptions.Description)
 	cmd.Flags().BoolVar(&noVerifierNonce, constants.NoVerifierNonceOptions.Name, false, constants.NoVerifierNonceOptions.Description)
+	cmd.Flags().StringVar(&verifierNonceJSON, constants.VerifierNonceOptions.Name, "", constants.VerifierNonceOptions.Description)
 	cmd.Flags().StringVarP(&userData, constants.UserDataOptions.Name, constants.UserDataOptions.ShortHand, "", constants.UserDataOptions.Description)
 	cmd.Flags().StringVarP(&policyIds, constants.PolicyIdsOptions.Name, constants.PolicyIdsOptions.ShortHand, "", constants.PolicyIdsOptions.Description)
 	cmd.Flags().StringVarP(&tokenSigningAlg, constants.TokenAlgOptions.Name, constants.TokenAlgOptions.ShortHand, "", constants.TokenAlgOptions.Description)

--- a/tdx-cli/cmd/evidence_test.go
+++ b/tdx-cli/cmd/evidence_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// testVerifierNonceJSON is a valid JSON-encoded connector.VerifierNonce used in tests.
+const testVerifierNonceJSON = `{"val":"bm9uY2UtdmFs","iat":"bm9uY2UtaWF0","signature":"bm9uY2Utc2ln"}`
+
 func TestEvidence(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -173,6 +176,88 @@ func TestEvidence(t *testing.T) {
 				"--" + constants.WithCcelOptions.Name,
 			},
 			errorExpected: true,
+		},
+		{
+			name: "Test Evidence User-Provided Verifier Nonce Positive",
+			dependencyMocks: func() (TdxAdapterFactory, tpm.TpmAdapterFactory, ConfigFactory, connector.ConnectorFactory) {
+				angryConnectorFactory := MockConnectorFactory{}
+				angryConnectorFactory.On("NewConnector", mock.Anything).Return(&MockConnector{}, errors.New("connector factory must not be called when --verifier-nonce is provided"))
+
+				return happyMockTdxAdapterFactory(), happyMockTpmAdapterFactory(), mockConfigFactory(nil), &angryConnectorFactory
+			},
+			cmdArgs: []string{
+				constants.EvidenceCmd,
+				"--" + constants.ConfigOptions.Name,
+				testNonExistentFileName,
+				"--" + constants.WithTdxOptions.Name,
+				"--" + constants.VerifierNonceOptions.Name,
+				testVerifierNonceJSON,
+			},
+			errorExpected: false,
+		},
+		{
+			name: "Test Evidence User-Provided Verifier Nonce With User Data",
+			dependencyMocks: func() (TdxAdapterFactory, tpm.TpmAdapterFactory, ConfigFactory, connector.ConnectorFactory) {
+				angryConnectorFactory := MockConnectorFactory{}
+				angryConnectorFactory.On("NewConnector", mock.Anything).Return(&MockConnector{}, errors.New("connector factory must not be called when --verifier-nonce is provided"))
+
+				return happyMockTdxAdapterFactory(), happyMockTpmAdapterFactory(), mockConfigFactory(nil), &angryConnectorFactory
+			},
+			cmdArgs: []string{
+				constants.EvidenceCmd,
+				"--" + constants.ConfigOptions.Name,
+				testNonExistentFileName,
+				"--" + constants.WithTdxOptions.Name,
+				"--" + constants.VerifierNonceOptions.Name,
+				testVerifierNonceJSON,
+				"--" + constants.UserDataOptions.Name,
+				"AA==",
+			},
+			errorExpected: false,
+		},
+		{
+			name: "Test Evidence Invalid Verifier Nonce JSON",
+			dependencyMocks: func() (TdxAdapterFactory, tpm.TpmAdapterFactory, ConfigFactory, connector.ConnectorFactory) {
+				return createDefaultMocks()
+			},
+			cmdArgs: []string{
+				constants.EvidenceCmd,
+				"--" + constants.ConfigOptions.Name,
+				testNonExistentFileName,
+				"--" + constants.WithTdxOptions.Name,
+				"--" + constants.VerifierNonceOptions.Name,
+				"not-valid-json",
+			},
+			errorExpected: true,
+		},
+		{
+			name: "Test Evidence Verifier Nonce and No-Verifier-Nonce Are Mutually Exclusive",
+			dependencyMocks: func() (TdxAdapterFactory, tpm.TpmAdapterFactory, ConfigFactory, connector.ConnectorFactory) {
+				return createDefaultMocks()
+			},
+			cmdArgs: []string{
+				constants.EvidenceCmd,
+				"--" + constants.ConfigOptions.Name,
+				testNonExistentFileName,
+				"--" + constants.WithTdxOptions.Name,
+				"--" + constants.NoVerifierNonceOptions.Name,
+				"--" + constants.VerifierNonceOptions.Name,
+				testVerifierNonceJSON,
+			},
+			errorExpected: true,
+		},
+		{
+			name: "Test Evidence Auto-Fetch Nonce Calls Connector Factory",
+			dependencyMocks: func() (TdxAdapterFactory, tpm.TpmAdapterFactory, ConfigFactory, connector.ConnectorFactory) {
+				return createDefaultMocks()
+			},
+			cmdArgs: []string{
+				constants.EvidenceCmd,
+				"--" + constants.ConfigOptions.Name,
+				testNonExistentFileName,
+				"--" + constants.WithTdxOptions.Name,
+			},
+			errorExpected: false,
 		},
 	}
 

--- a/tdx-cli/cmd/nonce_connector.go
+++ b/tdx-cli/cmd/nonce_connector.go
@@ -1,0 +1,48 @@
+/*
+ *   Copyright (c) 2022-2024 Intel Corporation
+ *   All rights reserved.
+ *   SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package cmd
+
+import (
+	"crypto/x509"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/intel/trustauthority-client/go-connector"
+	"github.com/pkg/errors"
+)
+
+// staticNonceConnector implements connector.Connector but only supports GetNonce.
+type staticNonceConnector struct {
+	nonce *connector.VerifierNonce
+}
+
+func (s *staticNonceConnector) GetNonce(args connector.GetNonceArgs) (connector.GetNonceResponse, error) {
+	return connector.GetNonceResponse{Nonce: s.nonce}, nil
+}
+
+func (s *staticNonceConnector) GetTokenSigningCertificates() ([]byte, error) {
+	return nil, errors.New("not supported by staticNonceConnector")
+}
+
+func (s *staticNonceConnector) GetToken(args connector.GetTokenArgs) (connector.GetTokenResponse, error) {
+	return connector.GetTokenResponse{}, errors.New("not supported by staticNonceConnector")
+}
+
+func (s *staticNonceConnector) Attest(args connector.AttestArgs) (connector.AttestResponse, error) {
+	return connector.AttestResponse{}, errors.New("not supported by staticNonceConnector")
+}
+
+func (s *staticNonceConnector) VerifyToken(tokenString string) (*jwt.Token, error) {
+	return nil, errors.New("not supported by staticNonceConnector")
+}
+
+func (s *staticNonceConnector) AttestEvidence(evidence interface{}, cloudProvider string, reqId string) (connector.AttestResponse, error) {
+	return connector.AttestResponse{}, errors.New("not supported by staticNonceConnector")
+}
+
+func (s *staticNonceConnector) GetAKCertificate(ekCert *x509.Certificate, akTpmtPublic []byte) ([]byte, []byte, []byte, error) {
+	return nil, nil, nil, errors.New("not supported by staticNonceConnector")
+}

--- a/tdx-cli/constants/constants.go
+++ b/tdx-cli/constants/constants.go
@@ -49,6 +49,7 @@ var (
 	WithTdxOptions         = CommandOptions{"tdx", "", "Include TDX evidence in evidence output (root privileges required)"}
 	WithNvGpuOptions       = CommandOptions{"nvgpu", "", "Include NVGPU evidence in evidence output"}
 	NoVerifierNonceOptions = CommandOptions{"no-verifier-nonce", "", "Do not include an ITA verifier-nonce in evidence"}
+	VerifierNonceOptions   = CommandOptions{"verifier-nonce", "", "User-provided ITA verifier nonce as a JSON object (e.g. '{\"val\":\"...\",\"iat\":\"...\",\"signature\":\"...\"}')"}
 	UserDataOptions        = CommandOptions{"user-data", "u", "User data in base64 encoded format"}
 	PolicyIdsOptions       = CommandOptions{"policy-ids", "p", "Trust Authority Policy Ids, comma separated"}
 	TokenAlgOptions        = CommandOptions{"token-signing-alg", "a", "Token signing algorithm to be used, support PS384 and RS256"}


### PR DESCRIPTION
In background check mode, allow users to specify ITA nonce from the relying party instead of obtaining the nonce using the trust authority client.